### PR TITLE
Changes to download-seafile.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,8 @@ ENV DEBIAN_FRONTEND noninteractive
 
 # Seafile dependencies and system configuration
 RUN apt-get update && \
-    apt-get install -y python2.7 python-setuptools python-simplejson python-imaging sqlite3 python-mysqldb python-memcache
+    apt-get install -y python2.7 python-setuptools python-simplejson python-imaging sqlite3 python-mysqldb python-memcache wget socat
 RUN ulimit -n 30000
-
-# Workaround for https://github.com/haiwen/seafile/issues/478
-RUN apt-get install -y socat
 
 # Interface the environment
 RUN mkdir /opt/seafile

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Consider using a reverse proxy for using HTTPs.
 
 1. After the container is started, run `download-seafile` to download Seafile and prepare setting it up.
 2. Once downloaded, run `/opt/seafile/seafile-server-4.*/setup-seafile.sh`, and go through the setup assistant. Do not change the port and storage location defaults, but change the run command appropriately.
+3. Run `/opt/seafile/seafile-server-latest/seafile.sh start` to start the seafile controller process.
 3. Run `/opt/seafile/seafile-server-latest/seahub.sh start` for configuring the web UI.
 4. If you want, do more configuration of Seafile. You can also already try it out.
 5. Setting up Seafile is finished, `exit` the container.

--- a/download-seafile.sh
+++ b/download-seafile.sh
@@ -1,10 +1,38 @@
-#!/bin/sh
+#!/bin/bash
 
 cd /opt/seafile
 arch=$(uname -m | sed s/"_"/"-"/g)
 regexp="http(s?):\/\/[^ \"\(\)\<\>]*seafile-server_[\d\.\_]*$arch.tar.gz"
-addr=`wget http://www.seafile.com/en/download/ -O - | grep --only-matching --perl-regexp "$regexp" | head -1`
-curl -L -O $addr || curl -L -O https://bitbucket.org/haiwen/seafile/downloads/seafile-server_4.1.2_x86-64.tar.gz;
-tar xzf seafile-server_*
-mkdir -p installed
-mv seafile-server_* installed
+
+which wget > /dev/null
+wget=$?
+which curl > /dev/null
+curl=$?
+if [ $wget -eq 0 ]; then
+    addr=$(wget http://www.seafile.com/en/download/ -O - | grep -o -P "$regexp" | head -1)
+    wget $addr
+elif [ $curl -eq 0 ]; then
+    addr=$(curl -Ls http://www.seafile.com/en/download/ | grep -o -P "$regexp" | head -1)
+    curl -Ls -O $addr 
+else
+    echo "Neither curl nor wget found. Exiting."
+    exit 1
+fi
+
+# figure out what directory the tarball is going to create
+file=$( echo $addr | awk -F/ '{ print $NF }' )
+
+# test that we got something
+if [ ! -z $file -a -f $file ]; then
+    dir=$( tar tvzf $file 2>/dev/null | head -n 1 | awk '{ print $NF }' | sed -e 's!/!!g')
+    tar xzf $file
+
+    # mkdir only if we don't already have one
+    [ ! -d installed ] && mkdir installed
+
+    # move the tarball only if we created the directory
+    [ -d $dir ] && mv seafile-server_* installed
+else
+    echo "Seafile install file not downloaded. Exiting."
+    exit 1
+fi

--- a/seafile.sh
+++ b/seafile.sh
@@ -1,15 +1,24 @@
-#!/bin/sh
+#!/bin/bash
 
-[ "${autostart}" = 'true' -a -x /opt/seafile/seafile-server-latest/seafile.sh ] || exit 0
+log=/var/log/seafile.log
+
+function stop_server() {
+    kill $( ps ax | grep -E 'seafile-controller|ccnet-server|seaf-server' | grep -v grep | awk '{ print $1 }' | xargs )
+    exit 0
+}
+
+trap stop_server SIGINT SIGTERM
+
+[[ "${autostart}" =~ ^[Tt]rue && -x /opt/seafile/seafile-server-latest/seafile.sh ]] || exit 0
 
 # Fix for https://github.com/haiwen/seafile/issues/478, forward seafdav localhost-only port
-[ "${workaround478}" = 'true' ] && socat TCP4-LISTEN:8080,fork TCP4:localhost:8081 &
+[[ "${workaround478}" =~ [Tt]rue ]] && socat TCP4-LISTEN:8080,fork TCP4:localhost:8081 &
 
-/opt/seafile/seafile-server-latest/seafile.sh start >>/var/log/seafile.log 2>&1
+/opt/seafile/seafile-server-latest/seafile.sh start >> $log 2>&1
 
 # Script should not exit unless seafile died
 while pgrep -f "seafile-controller" 2>&1 >/dev/null; do
-	sleep 10;
+    sleep 5;
 done
 
-exit 1
+exit 0

--- a/seahub.sh
+++ b/seahub.sh
@@ -1,17 +1,25 @@
-#!/bin/sh
+#!/bin/bash
 
-[ "${autostart}" = 'true' -a -x /opt/seafile/seafile-server-latest/seahub.sh ] || exit 0
+log=/var/log/seafile.log
 
-if [ "${fastcgi}" = 'true' ]
+function stop_server() {
+  ps ax | grep run_gunicorn | awk '{ print $1 }' | xargs kill
+}
+
+trap stop_server SIGINT SIGTERM
+
+[[ "${autostart}" =~ [Tt]rue && -x /opt/seafile/seafile-server-latest/seahub.sh ]] || exit 0
+
+if [[ "${fastcgi}" =~ [Tt]rue ]]
 then
-	SEAFILE_FASTCGI_HOST='0.0.0.0' /opt/seafile/seafile-server-latest/seahub.sh start-fastcgi >>/var/log/seafile.log 2>&1
+    SEAFILE_FASTCGI_HOST='0.0.0.0' /opt/seafile/seafile-server-latest/seahub.sh start-fastcgi >> $log
 else
-	/opt/seafile/seafile-server-latest/seahub.sh start >>/var/log/seafile.log 2>&1
+    /opt/seafile/seafile-server-latest/seahub.sh start >> $log 2>&1
 fi
 
 # Script should not exit unless seahub died
 while pgrep -f "manage.py run_gunicorn" 2>&1 >/dev/null; do
-	sleep 10;
+    sleep 5;
 done
 
-exit 1
+exit 0


### PR DESCRIPTION
The image you're derived from doesn't ship with `wget`. Your install script tried to pull something with `wget`, which fails, then uses curl to try and pull what it hoped `wget` figured out. This also fails, and then as a fallback the script downloads v4.1.2. I've rewritten the script to have error handling, to use either `wget` or `curl` if either is available, to not try to move things to directories that might not have been created, and so on. The result is an install of v4.3.1, after which your instructions work. I added a step to start the `seafile` process before trying to start `seahub`. Without it the seahub step fails.

Finally, I consolidated your apt lines to prevent unnecessary layers and to install `wget`. This makes my `curl/wget` checking above unnecessary, but whatevs... :smile:  